### PR TITLE
add 2FA support via trusted device registration

### DIFF
--- a/custom_components/ugreen/__init__.py
+++ b/custom_components/ugreen/__init__.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_UGREEN_PORT,
     CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_CLIENT_ID,
     CONF_USE_HTTPS,
     CONF_CONFIG_INTERVAL,
     CONF_STATE_INTERVAL,
@@ -85,6 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         username=entry.options.get(CONF_USERNAME, entry.data.get(CONF_USERNAME)),
         password=entry.options.get(CONF_PASSWORD, entry.data.get(CONF_PASSWORD)),
         use_https=bool(entry.options.get(CONF_USE_HTTPS, entry.data.get(CONF_USE_HTTPS, False))),
+        client_id=entry.options.get(CONF_CLIENT_ID, entry.data.get(CONF_CLIENT_ID, "")),
         standalone_disks=standalone_disks,
     )
 

--- a/custom_components/ugreen/api.py
+++ b/custom_components/ugreen/api.py
@@ -70,6 +70,7 @@ class UgreenApiClient:
         token: str = "",
         use_https: bool = False,
         otp: bool = False,
+        client_id: str = "",
         standalone_disks: list[dict[str, Any]] | None = None,
     ):
 
@@ -84,6 +85,12 @@ class UgreenApiClient:
         self.password = password
         self.token = token
         self.otp = otp
+
+        # UGOS ties 2FA device trust to the UG-Client-Id header. Presenting
+        # the id of a device registered with trust=true lets an account with
+        # 2FA log in without a code. Empty means 'not a registered device'.
+        self.client_id = client_id
+
         self.standalone_disks = [
             disk for disk in (standalone_disks or []) if isinstance(disk, dict)
         ]
@@ -602,7 +609,7 @@ class UgreenApiClient:
                 payload_pk = {"username": self.username}
                 _LOGGER.debug("[UGREEN] login: fetch public key")
                 async with async_timeout.timeout(10):
-                    async with session.post(url_pk, json=payload_pk, ssl=self._ssl) as resp:
+                    async with session.post(url_pk, json=payload_pk, headers=self.client_headers, ssl=self._ssl) as resp:
                         resp.raise_for_status()
                         hdr = resp.headers.get("x-rsa-token", "")
                 if not hdr:
@@ -624,13 +631,17 @@ class UgreenApiClient:
                 payload = {
                     "is_simple": True,
                     "keepalive": True,
-                    "otp": bool(self.otp),
+                    # Declares that this client understands the 2FA
+                    # handshake. Sending False makes UGOS reject accounts
+                    # that have 2FA enabled with a misleading 'client is not
+                    # compatible with the firmware' error (code 9406).
+                    "otp": True,
                     "username": self.username,
                     "password": enc,
                 }
-                _LOGGER.debug("[UGREEN] login POST (otp=%s)", self.otp)
+                _LOGGER.debug("[UGREEN] login POST (registered=%s)", bool(self.client_id))
                 async with async_timeout.timeout(10):
-                    async with session.post(url_login, json=payload, ssl=self._ssl) as resp:
+                    async with session.post(url_login, json=payload, headers=self.client_headers, ssl=self._ssl) as resp:
                         resp.raise_for_status()
                         data = await resp.json()
 
@@ -639,10 +650,21 @@ class UgreenApiClient:
                     _LOGGER.error("[UGREEN] login failed code=%s msg=%s", data.get("code"), msg)
                     return False
 
-                token = (data.get("data") or {}).get("token")
-                
+                result = data.get("data") or {}
+                token = result.get("token")
+
                 if not token:
-                    _LOGGER.error("[UGREEN] login ok but token missing")
+                    # Password accepted, but UGOS wants the second factor.
+                    if result.get("enable_otp"):
+                        _LOGGER.error(
+                            "[UGREEN] account '%s' has 2FA enabled but Home "
+                            "Assistant is not registered as a trusted device. "
+                            "Reconfigure the integration, tick the 2FA box "
+                            "and enter a current code.",
+                            self.username,
+                        )
+                    else:
+                        _LOGGER.error("[UGREEN] login ok but token missing")
                     return False
 
                 self.token = token
@@ -653,6 +675,132 @@ class UgreenApiClient:
             except Exception as e:
                 _LOGGER.error("[UGREEN] login error: %s", e)
                 return False
+
+    @property
+    def client_headers(self) -> dict[str, str]:
+        """Header that identifies this install to UGOS for 2FA trust."""
+        return {"UG-Client-Id": self.client_id} if self.client_id else {}
+
+    async def enroll_trusted_device(
+        self,
+        session: aiohttp.ClientSession,
+        otp_code: str,
+    ) -> tuple[bool, str]:
+        """Complete the UGOS 2FA handshake once and register as trusted.
+
+        UGOS binds trust to the UG-Client-Id header sent during the OTP step, so
+        the caller must persist the returned id and send it on every later login.
+        Returns (success, client_id).
+        """
+        if not self.client_id:
+            self.client_id = uuid4().hex
+            _LOGGER.debug("[UGREEN] generated client id for 2FA enrolment")
+
+        try:
+            # 1) public key, stamped with the id we are about to enrol
+            url_pk = f"{self.base_url}/ugreen/v1/verify/check?token="
+            async with async_timeout.timeout(10):
+                async with session.post(
+                    url_pk,
+                    json={"username": self.username},
+                    headers=self.client_headers,
+                    ssl=self._ssl,
+                ) as resp:
+                    resp.raise_for_status()
+                    hdr = resp.headers.get("x-rsa-token", "")
+            if not hdr:
+                _LOGGER.error("[UGREEN] enrolment: missing x-rsa-token header")
+                return False, self.client_id
+
+            try:
+                pub_bytes = base64.b64decode(hdr)
+            except Exception:
+                pub_bytes = hdr.encode("utf-8")
+            try:
+                pub = serialization.load_der_public_key(pub_bytes)
+            except Exception:
+                pub = serialization.load_pem_public_key(pub_bytes)
+            enc = base64.b64encode(
+                pub.encrypt(self.password.encode("utf-8"), padding.PKCS1v15())
+            ).decode("ascii")
+
+            # 2) login, declaring 2FA support
+            async with async_timeout.timeout(10):
+                async with session.post(
+                    f"{self.base_url}/ugreen/v1/verify/login",
+                    json={
+                        "is_simple": True,
+                        "keepalive": True,
+                        "otp": True,
+                        "username": self.username,
+                        "password": enc,
+                    },
+                    headers=self.client_headers,
+                    ssl=self._ssl,
+                ) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json()
+
+            if data.get("code") != 200:
+                _LOGGER.error(
+                    "[UGREEN] enrolment login failed code=%s msg=%s",
+                    data.get("code"),
+                    data.get("msg") or data.get("debug") or "",
+                )
+                return False, self.client_id
+
+            result = data.get("data") or {}
+            if result.get("token"):
+                # Already trusted, nothing to enrol.
+                self.token = result["token"]
+                self._authed = True
+                _LOGGER.debug("[UGREEN] already trusted, no code needed")
+                return True, self.client_id
+
+            token_id = result.get("token_id")
+            if not token_id:
+                _LOGGER.error("[UGREEN] enrolment: no token_id in login response")
+                return False, self.client_id
+
+            # 3) answer the challenge and ask UGOS to remember this device
+            async with async_timeout.timeout(10):
+                async with session.post(
+                    f"{self.base_url}/ugreen/v1/verify/code/login",
+                    json={
+                        "code": otp_code,
+                        "type": 1,  # 1 = authenticator app, 2 = email
+                        "token_id": token_id,
+                        "trust_info": {
+                            "client_type": "pc",
+                            "system": "linux",
+                            "dev_name": "Home Assistant",
+                        },
+                        "trust": True,
+                    },
+                    headers=self.client_headers,
+                    ssl=self._ssl,
+                ) as resp:
+                    resp.raise_for_status()
+                    verify = await resp.json()
+
+            if verify.get("code") != 200:
+                _LOGGER.error(
+                    "[UGREEN] 2FA verification failed code=%s msg=%s",
+                    verify.get("code"),
+                    verify.get("msg") or verify.get("debug") or "",
+                )
+                return False, self.client_id
+
+            token = (verify.get("data") or {}).get("token")
+            if token:
+                self.token = token
+                self._authed = True
+            _LOGGER.info("[UGREEN] enrolled as a trusted device")
+            return True, self.client_id
+
+        except Exception as e:
+            _LOGGER.error("[UGREEN] enrolment error: %s", e)
+            return False, self.client_id
 
     async def _request(self, session: aiohttp.ClientSession, method: str, endpoint: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         """Single request helper with 1024-refresh; keeps noise low"""

--- a/custom_components/ugreen/config_flow.py
+++ b/custom_components/ugreen/config_flow.py
@@ -1,5 +1,6 @@
 import logging, aiohttp
 import voluptuous as vol
+from uuid import uuid4
 from typing import Any, Optional
 
 from homeassistant import config_entries
@@ -16,6 +17,9 @@ from .const import (
     CONF_USERNAME,
     CONF_PASSWORD,
     CONF_USE_HTTPS,
+    CONF_USE_OTP,
+    CONF_OTP_CODE,
+    CONF_CLIENT_ID,
     CONF_STATE_INTERVAL,
     CONF_CONFIG_INTERVAL,
     CONF_WS_INTERVAL,
@@ -163,6 +167,10 @@ class UgreenNasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._discovered_host = None
         self._discovered_port = None
         self._discovered_hostname = None
+        # Set while walking the optional 2FA registration step
+        self._pending_input: dict[str, Any] | None = None
+        self._trusted_client_id: str = ""
+        self._candidate_client_id: str = ""
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
@@ -257,6 +265,60 @@ class UgreenNasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user()
 
+    async def async_step_otp(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Enrol Home Assistant as a trusted UGOS device using a one-time code.
+
+        UGOS will not issue a token to a client that cannot answer a 2FA
+        challenge. Answering it once with trust=true binds the trust to our
+        client id, which is then stored and replayed on every later login.
+        """
+        errors: dict[str, str] = {}
+        pending = self._pending_input or {}
+
+        # Generate the id up front so the form can show what will be enrolled.
+        if not self._candidate_client_id:
+            self._candidate_client_id = uuid4().hex
+
+        if user_input is not None:
+            code = str(user_input.get(CONF_OTP_CODE, "")).strip()
+            if not code:
+                errors["base"] = "invalid_otp"
+            else:
+                api = UgreenApiClient(
+                    ugreen_nas_host=pending[CONF_UGREEN_HOST],
+                    ugreen_nas_port=int(pending[CONF_UGREEN_PORT]),
+                    username=pending[CONF_USERNAME],
+                    password=pending[CONF_PASSWORD],
+                    use_https=pending.get(CONF_USE_HTTPS, False),
+                    client_id=self._candidate_client_id,
+                )
+                try:
+                    async with aiohttp.ClientSession() as session:
+                        ok, client_id = await api.enroll_trusted_device(session, code)
+                except Exception as e:
+                    _LOGGER.exception("[UGREEN NAS] 2FA enrolment failed: %s", e)
+                    ok, client_id = False, self._candidate_client_id
+
+                if ok:
+                    self._trusted_client_id = client_id
+                    _LOGGER.info(
+                        "[UGREEN NAS] trusted device enrolled, client id %s",
+                        client_id,
+                    )
+                    # Re-enter the normal path; the flag stops us looping back.
+                    return await self.async_step_user(pending)
+                errors["base"] = "invalid_otp"
+
+        return self.async_show_form(
+            step_id="otp",
+            data_schema=vol.Schema({vol.Required(CONF_OTP_CODE): str}),
+            description_placeholders={"client_id": self._candidate_client_id},
+            errors=errors,
+        )
+
     async def async_step_user(
         self,
         user_input: dict[str, Any] | None = None,
@@ -266,6 +328,12 @@ class UgreenNasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             _LOGGER.debug("[UGREEN NAS] Received user input: %s", user_input)
+
+            # Account uses 2FA and we have not registered yet: collect a code
+            # first, since a plain login would be rejected with code 9406.
+            if user_input.get(CONF_USE_OTP) and not self._trusted_client_id:
+                self._pending_input = user_input
+                return await self.async_step_otp()
 
             entity_prefix = _normalize_entity_prefix(
                 user_input.get(CONF_ENTITY_PREFIX, "")
@@ -315,6 +383,7 @@ class UgreenNasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         username=user_input[CONF_USERNAME],
                         password=user_input[CONF_PASSWORD],
                         use_https=user_input.get(CONF_USE_HTTPS, False),
+                        client_id=self._trusted_client_id,
                     )
 
                     async with aiohttp.ClientSession() as session:
@@ -358,6 +427,7 @@ class UgreenNasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                         CONF_USERNAME: user_input[CONF_USERNAME],
                                         CONF_PASSWORD: user_input[CONF_PASSWORD],
                                         CONF_USE_HTTPS: user_input.get(CONF_USE_HTTPS, False),
+                                        CONF_CLIENT_ID: self._trusted_client_id,
                                         CONF_DISCOVERY_HOSTNAME: self._discovered_hostname or "",
                                         CONF_ENTITY_PREFIX: entity_prefix,
                                         CONF_DASHBOARD_DISK_COLUMNS: disk_columns,
@@ -389,6 +459,7 @@ class UgreenNasConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         default=DEFAULT_ENTITY_PREFIX,
                     ): str,
                     vol.Optional(CONF_USE_HTTPS, default=False): bool,
+                    vol.Optional(CONF_USE_OTP, default=False): bool,
                 }
             ),
             errors=errors,
@@ -408,6 +479,58 @@ class UgreenNasOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry):
         self._entry = config_entry
+        # Set while walking the optional 2FA registration step
+        self._pending_options: dict[str, Any] | None = None
+
+    async def async_step_otp(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> config_entries.ConfigFlowResult:
+        """Register this Home Assistant as a trusted UGOS device.
+
+        UGOS will not hand a token to a client that cannot answer a 2FA prompt.
+        Answering it once with trust=true binds the trust to our client id,
+        which is then replayed on every later login.
+        """
+        errors: dict[str, str] = {}
+        options = self._pending_options or {}
+        current = str(options.get(CONF_CLIENT_ID, "") or "")
+
+        if user_input is not None:
+            code = str(user_input.get(CONF_OTP_CODE, "")).strip()
+            if not code:
+                errors["base"] = "invalid_otp"
+            else:
+                api = UgreenApiClient(
+                    ugreen_nas_host=options[CONF_UGREEN_HOST],
+                    ugreen_nas_port=int(options[CONF_UGREEN_PORT]),
+                    username=options[CONF_USERNAME],
+                    password=options[CONF_PASSWORD],
+                    use_https=options.get(CONF_USE_HTTPS, False),
+                    client_id=current,
+                )
+                try:
+                    async with aiohttp.ClientSession() as session:
+                        ok, client_id = await api.enroll_trusted_device(session, code)
+                except Exception as e:
+                    _LOGGER.exception("[UGREEN NAS] 2FA enrolment failed: %s", e)
+                    ok, client_id = False, ""
+
+                if ok:
+                    options[CONF_CLIENT_ID] = client_id
+                    _LOGGER.info(
+                        "[UGREEN NAS] trusted device registered, client id %s",
+                        client_id,
+                    )
+                    return self.async_create_entry(title="", data=options)
+                errors["base"] = "invalid_otp"
+
+        return self.async_show_form(
+            step_id="otp",
+            data_schema=vol.Schema({vol.Required(CONF_OTP_CODE): str}),
+            description_placeholders={"client_id": current or "(a new one will be generated)"},
+            errors=errors,
+        )
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         """Handle the single-page options form."""
@@ -463,6 +586,18 @@ class UgreenNasOptionsFlowHandler(config_entries.OptionsFlow):
                 user_input[CONF_DASHBOARD_POOL_COLUMNS] = pool_columns
                 user_input[CONF_DASHBOARD_VOLUME_COLUMNS] = volume_columns
                 user_input[CONF_DASHBOARD_IMAGE_FILE] = image_file
+                # The trusted device id is not part of the form, so carry the
+                # stored value across or it would be dropped on every save.
+                user_input[CONF_CLIENT_ID] = self._entry.options.get(
+                    CONF_CLIENT_ID, self._entry.data.get(CONF_CLIENT_ID, "")
+                )
+
+                # Ticking the box means "register a trusted device", which
+                # needs a code, so hand off to the dedicated step.
+                if user_input.pop(CONF_USE_OTP, False):
+                    self._pending_options = user_input
+                    return await self.async_step_otp()
+
                 return self.async_create_entry(title="", data=user_input)
 
         def _get_value(key: str, default: Any = None) -> Any:
@@ -499,6 +634,7 @@ class UgreenNasOptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_USE_HTTPS,
                         default=_get_value(CONF_USE_HTTPS, False),
                     ): bool,
+                    vol.Optional(CONF_USE_OTP, default=False): bool,
                     vol.Required(
                         CONF_STATE_INTERVAL,
                         default=_get_value(

--- a/custom_components/ugreen/const.py
+++ b/custom_components/ugreen/const.py
@@ -12,6 +12,11 @@ CONF_UGREEN_PORT = "ugreen_port"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_USE_HTTPS = "use_https"
+# UGOS binds 2FA device trust to the UG-Client-Id header. These carry the
+# registered id, plus the one-shot code used to create the registration.
+CONF_USE_OTP = "use_otp"
+CONF_OTP_CODE = "otp_code"
+CONF_CLIENT_ID = "client_id"
 
 CONF_STATE_INTERVAL = "state_interval"
 CONF_CONFIG_INTERVAL = "config_interval"

--- a/custom_components/ugreen/translations/de.json
+++ b/custom_components/ugreen/translations/de.json
@@ -10,7 +10,8 @@
           "username": "Admin Benutzername",
           "password": "Admin Passwort",
           "entity_prefix": "Eindeutiger Gerätename (Standard: UGREEN NAS)",
-          "use_https": "HTTPS verwenden"
+          "use_https": "HTTPS verwenden",
+          "use_otp": "Konto verwendet Zwei-Faktor-Authentifizierung (2FA)"
         },
         "data_description": {
           "ugreen_host": "Die IP-Adresse oder der Hostname deines UGREEN NAS (z. B. 192.168.1.100).",
@@ -18,12 +19,23 @@
           "username": "Dein NAS Admin Benutzername.",
           "password": "Dein NAS Admin Passwort (keine Sonderzeichen - UGOS Bug!).",
           "entity_prefix": "Muss mit einem Buchstaben beginnen; danach sind Buchstaben, Zahlen und Leerzeichen erlaubt.",
-          "use_https": "HTTPS für die Verbindung benutzen."
+          "use_https": "HTTPS für die Verbindung benutzen.",
+          "use_otp": "Aktiviere dies nur, wenn für das oben angegebene NAS-Konto 2FA eingeschaltet ist. Im nächsten Schritt wirst du nach einem Code gefragt, mit dem Home Assistant als vertrauenswürdiges Gerät registriert wird und danach keinen Code mehr benötigt."
         }
       },
       "zeroconf": {
         "title": "UGREEN NAS gefunden",
         "description": "Ein UGREEN NAS wurde automatisch im Netzwerk gefunden. Gib deine Anmeldedaten ein, um es hinzuzufügen."
+      },
+      "otp": {
+        "title": "Home Assistant als vertrauenswürdiges Gerät registrieren",
+        "description": "Für dein NAS-Konto ist Zwei-Faktor-Authentifizierung aktiv. Home Assistant kann nicht bei jeder Neuverbindung einen Code abfragen und registriert sich deshalb einmalig als vertrauenswürdiges Gerät.\n\nGib einen aktuellen Code aus deiner Authenticator-App ein. Er wird sofort verwendet und nicht gespeichert.\n\nGeräte-ID, die registriert wird: `{client_id}`\n\nDiese ID wird automatisch erzeugt und verwaltet. Du musst sie dir nicht notieren und nirgendwo eintragen.",
+        "data": {
+          "otp_code": "Authenticator-Code"
+        },
+        "data_description": {
+          "otp_code": "Der aktuelle 6-stellige Code aus deiner Authenticator-App. Codes laufen schnell ab, bestätige also zügig."
+        }
       }
     },
     "error": {
@@ -31,7 +43,8 @@
       "invalid_auth": "Verbindungsfehler oder ungültige Anmeldedaten. Netzwerkeinstellungen und Benutzereinstellungen prüfen.",
       "invalid_entity_prefix": "Ungültiger Gerätename. Er muss mit einem Buchstaben beginnen; danach sind nur Buchstaben, Zahlen und Leerzeichen erlaubt.",
       "entity_prefix_in_use": "Dieser Gerätename wird bereits von einem anderen UGREEN NAS verwendet.",
-      "unknown": "Ein unbekannter Fehler ist aufgetreten."
+      "unknown": "Ein unbekannter Fehler ist aufgetreten.",
+      "invalid_otp": "Registrierung fehlgeschlagen. Der Code ist möglicherweise abgelaufen oder falsch eingegeben, oder für das Konto ist keine 2FA aktiviert. Prüfe die Protokolle und versuche es mit einem neuen Code."
     },
     "abort": {
       "already_configured": "Dieses UGREEN NAS ist bereits konfiguriert."
@@ -55,7 +68,8 @@
           "dashboard_disk_columns": "[Beispiel-Dashboard] Maximale Anzahl Disk-Spalten pro Zeile (5)",
           "dashboard_pool_columns": "[Beispiel-Dashboard] Maximale Anzahl Pool-Spalten pro Zeile (2)",
           "dashboard_volume_columns": "[Beispiel-Dashboard] Maximale Anzahl Volume-Spalten pro Zeile (2)",
-          "dashboard_image_file": "[Beispiel-Dashboard] Name der Bilddatei (default_picture.png)"
+          "dashboard_image_file": "[Beispiel-Dashboard] Name der Bilddatei (default_picture.png)",
+          "use_otp": "Vertrauenswürdiges Gerät für Zwei-Faktor-Authentifizierung (2FA) registrieren"
         },
         "data_description": {
           "ugreen_host": "Die IP-Adresse oder der Hostname deines UGREEN NAS.",
@@ -70,9 +84,23 @@
           "dashboard_disk_columns": "Anzahl der Disk-Kacheln dieses NAS, die auf dem Dashboard nebeneinander angezeigt werden.",
           "dashboard_pool_columns": "Anzahl der Pool-Kacheln dieses NAS, die auf dem Dashboard nebeneinander angezeigt werden.",
           "dashboard_volume_columns": "Anzahl der Volume-Kacheln dieses NAS, die auf dem Dashboard nebeneinander angezeigt werden.",
-          "dashboard_image_file": "Individuelle Dashboard-Bilddatei für dieses NAS im Ordner www/community/ugreen/."
+          "dashboard_image_file": "Individuelle Dashboard-Bilddatei für dieses NAS im Ordner www/community/ugreen/.",
+          "use_otp": "Für normale Änderungen deaktiviert lassen. Aktiviere und speichere nur, wenn das NAS-Konto 2FA verwendet und Home Assistant noch nicht registriert ist oder erneut registriert werden muss. Im nächsten Schritt wirst du nach einem Code gefragt."
+        }
+      },
+      "otp": {
+        "title": "Vertrauenswürdiges Gerät registrieren",
+        "description": "Gib einen aktuellen Code aus deiner Authenticator-App ein, um diesen Home Assistant beim NAS zu registrieren. Der Code wird sofort verwendet und nicht gespeichert.\n\nAktuelle Geräte-ID: `{client_id}`\n\nDiese ID wird automatisch verwaltet und ist bewusst nicht bearbeitbar. Falls die Anmeldung fehlschlägt, nachdem du die Vertrauensstellung am NAS widerrufen hast, registriere hier einfach erneut.",
+        "data": {
+          "otp_code": "Authenticator-Code"
+        },
+        "data_description": {
+          "otp_code": "Der aktuelle 6-stellige Code. Codes laufen schnell ab, bestätige also zügig."
         }
       }
+    },
+    "error": {
+      "invalid_otp": "Registrierung fehlgeschlagen. Der Code ist möglicherweise abgelaufen oder falsch eingegeben. Versuche es mit einem neuen Code."
     }
   }
 }

--- a/custom_components/ugreen/translations/en.json
+++ b/custom_components/ugreen/translations/en.json
@@ -10,7 +10,8 @@
           "username": "Admin username",
           "password": "Admin password",
           "entity_prefix": "Unique device name (default: UGREEN NAS)",
-          "use_https": "Use HTTPS"
+          "use_https": "Use HTTPS",
+          "use_otp": "Account uses two-factor authentication (2FA)"
         },
         "data_description": {
           "ugreen_host": "The IP address or hostname of your UGREEN NAS (e.g. 192.168.1.100).",
@@ -18,12 +19,23 @@
           "username": "Your NAS admin username.",
           "password": "Your NAS admin password (no special characters – UGOS bug!).",
           "entity_prefix": "Must start with a letter; then letters, numbers, and spaces are allowed.",
-          "use_https": "Use HTTPS for the connection."
+          "use_https": "Use HTTPS for the connection.",
+          "use_otp": "Tick this only if the NAS account above has 2FA enabled. You will be asked for one code on the next screen, used to register Home Assistant as a trusted device so it never needs a code again."
         }
       },
       "zeroconf": {
         "title": "UGREEN NAS discovered",
         "description": "A UGREEN NAS was automatically discovered on the network. Enter your credentials to add it."
+      },
+      "otp": {
+        "title": "Register Home Assistant as a trusted device",
+        "description": "Your NAS account uses two-factor authentication. Home Assistant cannot answer a code prompt every time it reconnects, so it registers itself once as a trusted device.\n\nEnter a current code from your authenticator app. It is used immediately and never stored.\n\nDevice ID that will be registered: `{client_id}`\n\nThis ID is generated and managed automatically. You do not need to note it down or enter it anywhere.",
+        "data": {
+          "otp_code": "Authenticator code"
+        },
+        "data_description": {
+          "otp_code": "The current 6-digit code from your authenticator app. Codes expire quickly, so submit promptly."
+        }
       }
     },
     "error": {
@@ -31,7 +43,8 @@
       "invalid_auth": "Connection error or invalid credentials. Please check network and user settings.",
       "invalid_entity_prefix": "Invalid device name. It must start with a letter; afterwards only letters, numbers, and spaces are allowed.",
       "entity_prefix_in_use": "This device name is already used by another UGREEN NAS.",
-      "unknown": "An unknown error occurred."
+      "unknown": "An unknown error occurred.",
+      "invalid_otp": "Registration failed. The code may have expired or been mistyped, or the account may not have 2FA enabled. Check the logs and try a fresh code."
     },
     "abort": {
       "already_configured": "This UGREEN NAS is already configured."
@@ -55,7 +68,8 @@
           "dashboard_disk_columns": "[Example Dashboard] Max disk columns per row (5)",
           "dashboard_pool_columns": "[Example Dashboard] Max pool columns per row (2)",
           "dashboard_volume_columns": "[Example Dashboard] Max volume columns per row (2)",
-          "dashboard_image_file": "[Example Dashboard] Image file name (default_picture.png)"
+          "dashboard_image_file": "[Example Dashboard] Image file name (default_picture.png)",
+          "use_otp": "Register a two-factor (2FA) trusted device"
         },
         "data_description": {
           "ugreen_host": "The IP address or hostname of your UGREEN NAS.",
@@ -70,9 +84,23 @@
           "dashboard_disk_columns": "Number of disk tiles for this NAS to be shown side by side on the dashboard.",
           "dashboard_pool_columns": "Number of pool tiles for this NAS to be shown side by side on the dashboard.",
           "dashboard_volume_columns": "Number of volume tiles for this NAS to be shown side by side on the dashboard.",
-          "dashboard_image_file": "Individual dashboard image file for this NAS in the www/community/ugreen/ folder."
+          "dashboard_image_file": "Individual dashboard image file for this NAS in the www/community/ugreen/ folder.",
+          "use_otp": "Leave unticked for normal changes. Tick it and save only if the NAS account uses 2FA and Home Assistant is not registered yet, or you need to register again. You will be asked for one code on the next screen."
+        }
+      },
+      "otp": {
+        "title": "Register a trusted device",
+        "description": "Enter a current code from your authenticator app to register this Home Assistant with the NAS. The code is used immediately and never stored.\n\nCurrent device ID: `{client_id}`\n\nThis ID is managed automatically and is deliberately not editable. If logins start failing after revoking trust on the NAS, simply register again here.",
+        "data": {
+          "otp_code": "Authenticator code"
+        },
+        "data_description": {
+          "otp_code": "The current 6-digit code. Codes expire quickly, so submit promptly."
         }
       }
+    },
+    "error": {
+      "invalid_otp": "Registration failed. The code may have expired or been mistyped. Try a fresh code."
     }
   }
 }

--- a/custom_components/ugreen/translations/es.json
+++ b/custom_components/ugreen/translations/es.json
@@ -10,7 +10,8 @@
           "username": "Nombre de usuario administrador",
           "password": "Contraseña de administrador",
           "entity_prefix": "Nombre único del dispositivo (predeterminado: UGREEN NAS)",
-          "use_https": "Usar HTTPS"
+          "use_https": "Usar HTTPS",
+          "use_otp": "La cuenta usa autenticación de dos factores (2FA)"
         },
         "data_description": {
           "ugreen_host": "La dirección IP o el nombre de host de tu UGREEN NAS (p. ej. 192.168.1.100).",
@@ -18,12 +19,23 @@
           "username": "Tu nombre de usuario administrador del NAS.",
           "password": "Tu contraseña de administrador del NAS (sin caracteres especiales – ¡error de UGOS!).",
           "entity_prefix": "Debe comenzar con una letra; después se permiten letras, números y espacios.",
-          "use_https": "Usar HTTPS para la conexión."
+          "use_https": "Usar HTTPS para la conexión.",
+          "use_otp": "Marca esta casilla solo si la cuenta del NAS indicada arriba tiene la 2FA activada. En la siguiente pantalla se te pedirá un código, que se usará para registrar Home Assistant como dispositivo de confianza para que no vuelva a necesitar un código."
         }
       },
       "zeroconf": {
         "title": "UGREEN NAS detectado",
         "description": "Se ha detectado automáticamente un UGREEN NAS en la red. Introduce tus credenciales para añadirlo."
+      },
+      "otp": {
+        "title": "Registrar Home Assistant como dispositivo de confianza",
+        "description": "Tu cuenta del NAS usa autenticación de dos factores. Home Assistant no puede responder a una solicitud de código cada vez que se reconecta, así que se registra una vez como dispositivo de confianza.\n\nIntroduce un código actual de tu aplicación de autenticación. Se usa de inmediato y no se guarda.\n\nID del dispositivo que se registrará: `{client_id}`\n\nEsta ID se genera y se gestiona automáticamente. No necesitas anotarla ni introducirla en ningún sitio.",
+        "data": {
+          "otp_code": "Código de autenticación"
+        },
+        "data_description": {
+          "otp_code": "El código actual de 6 dígitos de tu aplicación de autenticación. Los códigos caducan rápido, así que envíalo cuanto antes."
+        }
       }
     },
     "error": {
@@ -31,7 +43,8 @@
       "invalid_auth": "Error de conexión o credenciales no válidas. Comprueba la configuración de red y del usuario.",
       "invalid_entity_prefix": "Nombre de dispositivo no válido. Debe comenzar con una letra; después solo se permiten letras, números y espacios.",
       "entity_prefix_in_use": "Este nombre de dispositivo ya está siendo utilizado por otro UGREEN NAS.",
-      "unknown": "Se ha producido un error desconocido."
+      "unknown": "Se ha producido un error desconocido.",
+      "invalid_otp": "Error en el registro. Puede que el código haya caducado o se haya escrito mal, o que la cuenta no tenga la 2FA activada. Revisa los registros y prueba con un código nuevo."
     },
     "abort": {
       "already_configured": "Este UGREEN NAS ya está configurado."
@@ -55,7 +68,8 @@
           "dashboard_disk_columns": "[Dashboard de ejemplo] Máx. columnas de discos por fila (5)",
           "dashboard_pool_columns": "[Dashboard de ejemplo] Máx. columnas de pools por fila (2)",
           "dashboard_volume_columns": "[Dashboard de ejemplo] Máx. columnas de volúmenes por fila (2)",
-          "dashboard_image_file": "[Dashboard de ejemplo] Nombre del archivo de imagen (default_picture.png)"
+          "dashboard_image_file": "[Dashboard de ejemplo] Nombre del archivo de imagen (default_picture.png)",
+          "use_otp": "Registrar un dispositivo de confianza para la 2FA"
         },
         "data_description": {
           "ugreen_host": "La dirección IP o el nombre de host de tu UGREEN NAS.",
@@ -70,9 +84,23 @@
           "dashboard_disk_columns": "Número de mosaicos de discos de este NAS que se mostrarán uno al lado del otro en el dashboard.",
           "dashboard_pool_columns": "Número de mosaicos de pools de este NAS que se mostrarán uno al lado del otro en el dashboard.",
           "dashboard_volume_columns": "Número de mosaicos de volúmenes de este NAS que se mostrarán uno al lado del otro en el dashboard.",
-          "dashboard_image_file": "Archivo de imagen individual del dashboard para este NAS en la carpeta www/community/ugreen/."
+          "dashboard_image_file": "Archivo de imagen individual del dashboard para este NAS en la carpeta www/community/ugreen/.",
+          "use_otp": "Déjalo sin marcar para los cambios normales. Márcalo y guarda solo si la cuenta del NAS usa 2FA y Home Assistant aún no está registrado, o si necesitas registrarlo de nuevo. En la siguiente pantalla se te pedirá un código."
+        }
+      },
+      "otp": {
+        "title": "Registrar un dispositivo de confianza",
+        "description": "Introduce un código actual de tu aplicación de autenticación para registrar este Home Assistant en el NAS. El código se usa de inmediato y no se guarda.\n\nID del dispositivo actual: `{client_id}`\n\nEsta ID se gestiona automáticamente y no es editable a propósito. Si los inicios de sesión fallan tras revocar la confianza en el NAS, vuelve a registrarlo aquí.",
+        "data": {
+          "otp_code": "Código de autenticación"
+        },
+        "data_description": {
+          "otp_code": "El código actual de 6 dígitos. Los códigos caducan rápido, así que envíalo cuanto antes."
         }
       }
+    },
+    "error": {
+      "invalid_otp": "Error en el registro. Puede que el código haya caducado o se haya escrito mal. Prueba con un código nuevo."
     }
   }
 }

--- a/custom_components/ugreen/translations/fr.json
+++ b/custom_components/ugreen/translations/fr.json
@@ -10,7 +10,8 @@
           "username": "Nom d’utilisateur administrateur",
           "password": "Mot de passe administrateur",
           "entity_prefix": "Nom d’appareil unique (par défaut : UGREEN NAS)",
-          "use_https": "Utiliser HTTPS"
+          "use_https": "Utiliser HTTPS",
+          "use_otp": "Le compte utilise l’authentification à deux facteurs (2FA)"
         },
         "data_description": {
           "ugreen_host": "L’adresse IP ou le nom d’hôte de votre UGREEN NAS (par ex. 192.168.1.100).",
@@ -18,12 +19,23 @@
           "username": "Votre nom d’utilisateur administrateur du NAS.",
           "password": "Votre mot de passe administrateur du NAS (pas de caractères spéciaux – bug UGOS !).",
           "entity_prefix": "Doit commencer par une lettre ; ensuite, les lettres, chiffres et espaces sont autorisés.",
-          "use_https": "Utiliser HTTPS pour la connexion."
+          "use_https": "Utiliser HTTPS pour la connexion.",
+          "use_otp": "Cochez cette case uniquement si la 2FA est activée sur le compte NAS ci-dessus. Un code vous sera demandé à l’écran suivant, afin d’enregistrer Home Assistant comme appareil de confiance et de ne plus avoir à saisir de code."
         }
       },
       "zeroconf": {
         "title": "UGREEN NAS détecté",
         "description": "Un UGREEN NAS a été détecté automatiquement sur le réseau. Saisissez vos identifiants pour l’ajouter."
+      },
+      "otp": {
+        "title": "Enregistrer Home Assistant comme appareil de confiance",
+        "description": "Votre compte NAS utilise l’authentification à deux facteurs. Home Assistant ne peut pas répondre à une demande de code à chaque reconnexion ; il s’enregistre donc une seule fois comme appareil de confiance.\n\nSaisissez un code actuel depuis votre application d’authentification. Il est utilisé immédiatement et n’est jamais conservé.\n\nIdentifiant de l’appareil qui sera enregistré : `{client_id}`\n\nCet identifiant est généré et géré automatiquement. Vous n’avez pas besoin de le noter ni de le saisir ailleurs.",
+        "data": {
+          "otp_code": "Code d’authentification"
+        },
+        "data_description": {
+          "otp_code": "Le code à 6 chiffres actuel de votre application d’authentification. Les codes expirent vite, validez rapidement."
+        }
       }
     },
     "error": {
@@ -31,7 +43,8 @@
       "invalid_auth": "Erreur de connexion ou identifiants invalides. Veuillez vérifier les paramètres réseau et utilisateur.",
       "invalid_entity_prefix": "Nom d’appareil invalide. Il doit commencer par une lettre ; ensuite, seuls les lettres, chiffres et espaces sont autorisés.",
       "entity_prefix_in_use": "Ce nom d’appareil est déjà utilisé par un autre UGREEN NAS.",
-      "unknown": "Une erreur inconnue s’est produite."
+      "unknown": "Une erreur inconnue s’est produite.",
+      "invalid_otp": "Échec de l’enregistrement. Le code a peut-être expiré ou été mal saisi, ou la 2FA n’est pas activée sur le compte. Consultez les journaux et réessayez avec un nouveau code."
     },
     "abort": {
       "already_configured": "Ce UGREEN NAS est déjà configuré."
@@ -55,7 +68,8 @@
           "dashboard_disk_columns": "[Dashboard exemple] Nombre max. de colonnes de disques par ligne (5)",
           "dashboard_pool_columns": "[Dashboard exemple] Nombre max. de colonnes de pools par ligne (2)",
           "dashboard_volume_columns": "[Dashboard exemple] Nombre max. de colonnes de volumes par ligne (2)",
-          "dashboard_image_file": "[Dashboard exemple] Nom du fichier image (default_picture.png)"
+          "dashboard_image_file": "[Dashboard exemple] Nom du fichier image (default_picture.png)",
+          "use_otp": "Enregistrer un appareil de confiance pour la 2FA"
         },
         "data_description": {
           "ugreen_host": "L’adresse IP ou le nom d’hôte de votre UGREEN NAS.",
@@ -70,9 +84,23 @@
           "dashboard_disk_columns": "Nombre de tuiles de disques de ce NAS à afficher côte à côte sur le dashboard.",
           "dashboard_pool_columns": "Nombre de tuiles de pools de ce NAS à afficher côte à côte sur le dashboard.",
           "dashboard_volume_columns": "Nombre de tuiles de volumes de ce NAS à afficher côte à côte sur le dashboard.",
-          "dashboard_image_file": "Fichier image individuel du dashboard pour ce NAS dans le dossier www/community/ugreen/."
+          "dashboard_image_file": "Fichier image individuel du dashboard pour ce NAS dans le dossier www/community/ugreen/.",
+          "use_otp": "Laissez décoché pour les modifications habituelles. Cochez puis enregistrez uniquement si le compte NAS utilise la 2FA et que Home Assistant n’est pas encore enregistré, ou si vous devez l’enregistrer à nouveau. Un code vous sera demandé à l’écran suivant."
+        }
+      },
+      "otp": {
+        "title": "Enregistrer un appareil de confiance",
+        "description": "Saisissez un code actuel depuis votre application d’authentification pour enregistrer ce Home Assistant auprès du NAS. Le code est utilisé immédiatement et n’est jamais conservé.\n\nIdentifiant actuel de l’appareil : `{client_id}`\n\nCet identifiant est géré automatiquement et n’est volontairement pas modifiable. Si les connexions échouent après la révocation de la confiance sur le NAS, enregistrez-le à nouveau ici.",
+        "data": {
+          "otp_code": "Code d’authentification"
+        },
+        "data_description": {
+          "otp_code": "Le code à 6 chiffres actuel. Les codes expirent vite, validez rapidement."
         }
       }
+    },
+    "error": {
+      "invalid_otp": "Échec de l’enregistrement. Le code a peut-être expiré ou été mal saisi. Réessayez avec un nouveau code."
     }
   }
 }

--- a/custom_components/ugreen/translations/hu.json
+++ b/custom_components/ugreen/translations/hu.json
@@ -10,7 +10,8 @@
           "username": "Admin felhasználónév",
           "password": "Admin jelszó",
           "entity_prefix": "Egyedi eszköznév (alapértelmezett: UGREEN NAS)",
-          "use_https": "HTTPS használata"
+          "use_https": "HTTPS használata",
+          "use_otp": "A fiók kétfaktoros hitelesítést (2FA) használ"
         },
         "data_description": {
           "ugreen_host": "Az UGREEN NAS IP-címe vagy hosztneve (pl. 192.168.1.100).",
@@ -18,12 +19,23 @@
           "username": "A NAS admin felhasználóneved.",
           "password": "A NAS admin jelszavad (nincsenek speciális karakterek – UGOS hiba!).",
           "entity_prefix": "Betűvel kell kezdődnie; utána betűk, számok és szóközök engedélyezettek.",
-          "use_https": "HTTPS használata a kapcsolathoz."
+          "use_https": "HTTPS használata a kapcsolathoz.",
+          "use_otp": "Csak akkor jelöld be, ha a fenti NAS-fiókon be van kapcsolva a 2FA. A következő képernyőn egy kódot kérünk, amellyel a Home Assistant megbízható eszközként regisztrálódik, így később nem lesz szükség kódra."
         }
       },
       "zeroconf": {
         "title": "UGREEN NAS észlelve",
         "description": "Egy UGREEN NAS automatikusan észlelve lett a hálózaton. Add meg a bejelentkezési adataidat a hozzáadáshoz."
+      },
+      "otp": {
+        "title": "A Home Assistant regisztrálása megbízható eszközként",
+        "description": "A NAS-fiókod kétfaktoros hitelesítést használ. A Home Assistant nem tud minden újracsatlakozáskor kódot megadni, ezért egyszer megbízható eszközként regisztrálja magát.\n\nAdd meg a hitelesítő alkalmazásod aktuális kódját. A rendszer azonnal felhasználja, és soha nem tárolja.\n\nA regisztrálandó eszközazonosító: `{client_id}`\n\nEzt az azonosítót a rendszer automatikusan hozza létre és kezeli. Nem kell feljegyezned, és sehova nem kell beírnod.",
+        "data": {
+          "otp_code": "Hitelesítő kód"
+        },
+        "data_description": {
+          "otp_code": "A hitelesítő alkalmazás aktuális 6 jegyű kódja. A kódok gyorsan lejárnak, ezért küldd be mielőbb."
+        }
       }
     },
     "error": {
@@ -31,7 +43,8 @@
       "invalid_auth": "Kapcsolati hiba vagy érvénytelen hitelesítő adatok. Ellenőrizd a hálózati és a felhasználói beállításokat.",
       "invalid_entity_prefix": "Érvénytelen eszköznév. Betűvel kell kezdődnie; utána csak betűk, számok és szóközök engedélyezettek.",
       "entity_prefix_in_use": "Ezt az eszköznevet már egy másik UGREEN NAS használja.",
-      "unknown": "Ismeretlen hiba történt."
+      "unknown": "Ismeretlen hiba történt.",
+      "invalid_otp": "A regisztráció nem sikerült. Lehet, hogy a kód lejárt vagy elgépelted, vagy a fiókon nincs bekapcsolva a 2FA. Ellenőrizd a naplókat, és próbáld újra friss kóddal."
     },
     "abort": {
       "already_configured": "Ez az UGREEN NAS már be van állítva."
@@ -55,7 +68,8 @@
           "dashboard_disk_columns": "[Példa dashboard] Max. lemezoszlop soronként (5)",
           "dashboard_pool_columns": "[Példa dashboard] Max. pooltípus-oszlop soronként (2)",
           "dashboard_volume_columns": "[Példa dashboard] Max. kötetoszlop soronként (2)",
-          "dashboard_image_file": "[Példa dashboard] Képfájl neve (default_picture.png)"
+          "dashboard_image_file": "[Példa dashboard] Képfájl neve (default_picture.png)",
+          "use_otp": "Megbízható eszköz regisztrálása kétfaktoros hitelesítéshez (2FA)"
         },
         "data_description": {
           "ugreen_host": "Az UGREEN NAS IP-címe vagy hosztneve.",
@@ -70,9 +84,23 @@
           "dashboard_disk_columns": "Hány lemezcsempe jelenjen meg egymás mellett a dashboardon ennél a NAS-nál.",
           "dashboard_pool_columns": "Hány poolcsempe jelenjen meg egymás mellett a dashboardon ennél a NAS-nál.",
           "dashboard_volume_columns": "Hány kötetcsempe jelenjen meg egymás mellett a dashboardon ennél a NAS-nál.",
-          "dashboard_image_file": "Egyéni dashboard képfájl ehhez a NAS-hoz a www/community/ugreen/ mappában."
+          "dashboard_image_file": "Egyéni dashboard képfájl ehhez a NAS-hoz a www/community/ugreen/ mappában.",
+          "use_otp": "A szokásos módosításokhoz hagyd üresen. Csak akkor jelöld be és mentsd, ha a NAS-fiók 2FA-t használ, és a Home Assistant még nincs regisztrálva, vagy újra kell regisztrálni. A következő képernyőn egy kódot kérünk."
+        }
+      },
+      "otp": {
+        "title": "Megbízható eszköz regisztrálása",
+        "description": "Add meg a hitelesítő alkalmazásod aktuális kódját, hogy regisztráld ezt a Home Assistantot a NAS-on. A kódot a rendszer azonnal felhasználja, és soha nem tárolja.\n\nJelenlegi eszközazonosító: `{client_id}`\n\nEzt az azonosítót a rendszer automatikusan kezeli, és szándékosan nem szerkeszthető. Ha a bejelentkezés hibázni kezd, miután a NAS-on visszavontad a megbízhatóságot, egyszerűen regisztráld újra itt.",
+        "data": {
+          "otp_code": "Hitelesítő kód"
+        },
+        "data_description": {
+          "otp_code": "Az aktuális 6 jegyű kód. A kódok gyorsan lejárnak, ezért küldd be mielőbb."
         }
       }
+    },
+    "error": {
+      "invalid_otp": "A regisztráció nem sikerült. Lehet, hogy a kód lejárt vagy elgépelted. Próbáld újra friss kóddal."
     }
   }
 }

--- a/custom_components/ugreen/translations/it.json
+++ b/custom_components/ugreen/translations/it.json
@@ -10,7 +10,8 @@
           "username": "Nome utente amministratore",
           "password": "Password amministratore",
           "entity_prefix": "Nome dispositivo univoco (predefinito: UGREEN NAS)",
-          "use_https": "Usa HTTPS"
+          "use_https": "Usa HTTPS",
+          "use_otp": "L’account usa l’autenticazione a due fattori (2FA)"
         },
         "data_description": {
           "ugreen_host": "L’indirizzo IP o il nome host del tuo UGREEN NAS (ad es. 192.168.1.100).",
@@ -18,12 +19,23 @@
           "username": "Il tuo nome utente amministratore del NAS.",
           "password": "La tua password amministratore del NAS (senza caratteri speciali – bug di UGOS!).",
           "entity_prefix": "Deve iniziare con una lettera; poi sono consentiti lettere, numeri e spazi.",
-          "use_https": "Usa HTTPS per la connessione."
+          "use_https": "Usa HTTPS per la connessione.",
+          "use_otp": "Seleziona questa casella solo se per l’account NAS indicato sopra è attiva la 2FA. Nella schermata successiva ti verrà chiesto un codice, usato per registrare Home Assistant come dispositivo attendibile in modo che non serva più un codice."
         }
       },
       "zeroconf": {
         "title": "UGREEN NAS rilevato",
         "description": "Un UGREEN NAS è stato rilevato automaticamente sulla rete. Inserisci le tue credenziali per aggiungerlo."
+      },
+      "otp": {
+        "title": "Registra Home Assistant come dispositivo attendibile",
+        "description": "Il tuo account NAS usa l’autenticazione a due fattori. Home Assistant non può rispondere a una richiesta di codice a ogni riconnessione, quindi si registra una volta come dispositivo attendibile.\n\nInserisci un codice attuale dalla tua app di autenticazione. Viene usato subito e non viene mai memorizzato.\n\nID del dispositivo che verrà registrato: `{client_id}`\n\nQuesto ID viene generato e gestito automaticamente. Non devi annotarlo né inserirlo altrove.",
+        "data": {
+          "otp_code": "Codice di autenticazione"
+        },
+        "data_description": {
+          "otp_code": "Il codice a 6 cifre attuale della tua app di autenticazione. I codici scadono in fretta, quindi conferma subito."
+        }
       }
     },
     "error": {
@@ -31,7 +43,8 @@
       "invalid_auth": "Errore di connessione o credenziali non valide. Controlla le impostazioni di rete e dell’utente.",
       "invalid_entity_prefix": "Nome dispositivo non valido. Deve iniziare con una lettera; successivamente sono consentiti solo lettere, numeri e spazi.",
       "entity_prefix_in_use": "Questo nome dispositivo è già utilizzato da un altro UGREEN NAS.",
-      "unknown": "Si è verificato un errore sconosciuto."
+      "unknown": "Si è verificato un errore sconosciuto.",
+      "invalid_otp": "Registrazione non riuscita. Il codice potrebbe essere scaduto o digitato male, oppure l’account potrebbe non avere la 2FA attiva. Controlla i log e riprova con un codice nuovo."
     },
     "abort": {
       "already_configured": "Questo UGREEN NAS è già configurato."
@@ -55,7 +68,8 @@
           "dashboard_disk_columns": "[Dashboard di esempio] Max colonne dischi per riga (5)",
           "dashboard_pool_columns": "[Dashboard di esempio] Max colonne pool per riga (2)",
           "dashboard_volume_columns": "[Dashboard di esempio] Max colonne volumi per riga (2)",
-          "dashboard_image_file": "[Dashboard di esempio] Nome file immagine (default_picture.png)"
+          "dashboard_image_file": "[Dashboard di esempio] Nome file immagine (default_picture.png)",
+          "use_otp": "Registra un dispositivo attendibile per la 2FA"
         },
         "data_description": {
           "ugreen_host": "L’indirizzo IP o il nome host del tuo UGREEN NAS.",
@@ -70,9 +84,23 @@
           "dashboard_disk_columns": "Numero di riquadri disco di questo NAS da mostrare affiancati nel dashboard.",
           "dashboard_pool_columns": "Numero di riquadri pool di questo NAS da mostrare affiancati nel dashboard.",
           "dashboard_volume_columns": "Numero di riquadri volume di questo NAS da mostrare affiancati nel dashboard.",
-          "dashboard_image_file": "File immagine dashboard individuale per questo NAS nella cartella www/community/ugreen/."
+          "dashboard_image_file": "File immagine dashboard individuale per questo NAS nella cartella www/community/ugreen/.",
+          "use_otp": "Lascia deselezionato per le modifiche normali. Selezionalo e salva solo se l’account NAS usa la 2FA e Home Assistant non è ancora registrato, o se devi registrarlo di nuovo. Nella schermata successiva ti verrà chiesto un codice."
+        }
+      },
+      "otp": {
+        "title": "Registra un dispositivo attendibile",
+        "description": "Inserisci un codice attuale dalla tua app di autenticazione per registrare questo Home Assistant sul NAS. Il codice viene usato subito e non viene mai memorizzato.\n\nID dispositivo attuale: `{client_id}`\n\nQuesto ID è gestito automaticamente e non è modificabile di proposito. Se gli accessi iniziano a fallire dopo aver revocato l’attendibilità sul NAS, registralo di nuovo qui.",
+        "data": {
+          "otp_code": "Codice di autenticazione"
+        },
+        "data_description": {
+          "otp_code": "Il codice a 6 cifre attuale. I codici scadono in fretta, quindi conferma subito."
         }
       }
+    },
+    "error": {
+      "invalid_otp": "Registrazione non riuscita. Il codice potrebbe essere scaduto o digitato male. Riprova con un codice nuovo."
     }
   }
 }

--- a/custom_components/ugreen/translations/pt-br.json
+++ b/custom_components/ugreen/translations/pt-br.json
@@ -10,7 +10,8 @@
           "username": "Nome de usuário administrador",
           "password": "Senha de administrador",
           "entity_prefix": "Nome exclusivo do dispositivo (padrão: UGREEN NAS)",
-          "use_https": "Usar HTTPS"
+          "use_https": "Usar HTTPS",
+          "use_otp": "A conta usa autenticação em duas etapas (2FA)"
         },
         "data_description": {
           "ugreen_host": "O endereço IP ou nome do host do seu UGREEN NAS (ex.: 192.168.1.100).",
@@ -18,12 +19,23 @@
           "username": "Seu nome de usuário administrador do NAS.",
           "password": "Sua senha de administrador do NAS (sem caracteres especiais – bug do UGOS!).",
           "entity_prefix": "Deve começar com uma letra; depois disso, letras, números e espaços são permitidos.",
-          "use_https": "Usar HTTPS para a conexão."
+          "use_https": "Usar HTTPS para a conexão.",
+          "use_otp": "Marque esta opção somente se a conta do NAS acima tiver a 2FA ativada. Na próxima tela será solicitado um código, usado para registrar o Home Assistant como dispositivo confiável, para que não precise mais de um código."
         }
       },
       "zeroconf": {
         "title": "UGREEN NAS encontrado",
         "description": "Um UGREEN NAS foi encontrado automaticamente na rede. Informe suas credenciais para adicioná-lo."
+      },
+      "otp": {
+        "title": "Registrar o Home Assistant como dispositivo confiável",
+        "description": "Sua conta do NAS usa autenticação em duas etapas. O Home Assistant não pode responder a um pedido de código a cada reconexão, por isso ele se registra uma vez como dispositivo confiável.\n\nInforme um código atual do seu aplicativo autenticador. Ele é usado imediatamente e nunca é armazenado.\n\nID do dispositivo que será registrado: `{client_id}`\n\nEste ID é gerado e gerenciado automaticamente. Você não precisa anotá-lo nem informá-lo em outro lugar.",
+        "data": {
+          "otp_code": "Código do autenticador"
+        },
+        "data_description": {
+          "otp_code": "O código atual de 6 dígitos do seu aplicativo autenticador. Os códigos expiram rápido, então confirme logo."
+        }
       }
     },
     "error": {
@@ -31,7 +43,8 @@
       "invalid_auth": "Erro de conexão ou credenciais inválidas. Verifique as configurações de rede e do usuário.",
       "invalid_entity_prefix": "Nome do dispositivo inválido. Ele deve começar com uma letra; depois disso, apenas letras, números e espaços são permitidos.",
       "entity_prefix_in_use": "Este nome de dispositivo já está sendo usado por outro UGREEN NAS.",
-      "unknown": "Ocorreu um erro desconhecido."
+      "unknown": "Ocorreu um erro desconhecido.",
+      "invalid_otp": "Falha no registro. O código pode ter expirado ou sido digitado errado, ou a conta pode não ter a 2FA ativada. Verifique os logs e tente com um código novo."
     },
     "abort": {
       "already_configured": "Este UGREEN NAS já está configurado."
@@ -55,7 +68,8 @@
           "dashboard_disk_columns": "[Dashboard de exemplo] Máx. de colunas de discos por linha (5)",
           "dashboard_pool_columns": "[Dashboard de exemplo] Máx. de colunas de pools por linha (2)",
           "dashboard_volume_columns": "[Dashboard de exemplo] Máx. de colunas de volumes por linha (2)",
-          "dashboard_image_file": "[Dashboard de exemplo] Nome do arquivo de imagem (default_picture.png)"
+          "dashboard_image_file": "[Dashboard de exemplo] Nome do arquivo de imagem (default_picture.png)",
+          "use_otp": "Registrar um dispositivo confiável para 2FA"
         },
         "data_description": {
           "ugreen_host": "O endereço IP ou nome do host do seu UGREEN NAS.",
@@ -70,9 +84,23 @@
           "dashboard_disk_columns": "Número de blocos de disco deste NAS a serem exibidos lado a lado no dashboard.",
           "dashboard_pool_columns": "Número de blocos de pool deste NAS a serem exibidos lado a lado no dashboard.",
           "dashboard_volume_columns": "Número de blocos de volume deste NAS a serem exibidos lado a lado no dashboard.",
-          "dashboard_image_file": "Arquivo de imagem individual do dashboard para este NAS na pasta www/community/ugreen/."
+          "dashboard_image_file": "Arquivo de imagem individual do dashboard para este NAS na pasta www/community/ugreen/.",
+          "use_otp": "Deixe desmarcado para alterações normais. Marque e salve apenas se a conta do NAS usar 2FA e o Home Assistant ainda não estiver registrado, ou se precisar registrar novamente. Na próxima tela será solicitado um código."
+        }
+      },
+      "otp": {
+        "title": "Registrar um dispositivo confiável",
+        "description": "Informe um código atual do seu aplicativo autenticador para registrar este Home Assistant no NAS. O código é usado imediatamente e nunca é armazenado.\n\nID do dispositivo atual: `{client_id}`\n\nEste ID é gerenciado automaticamente e propositalmente não pode ser editado. Se os logins começarem a falhar após revogar a confiança no NAS, registre novamente aqui.",
+        "data": {
+          "otp_code": "Código do autenticador"
+        },
+        "data_description": {
+          "otp_code": "O código atual de 6 dígitos. Os códigos expiram rápido, então confirme logo."
         }
       }
+    },
+    "error": {
+      "invalid_otp": "Falha no registro. O código pode ter expirado ou sido digitado errado. Tente com um código novo."
     }
   }
 }


### PR DESCRIPTION
The integration was failing with 9406 "The client is not compatible with the firmware, please update the client", which points at a version problem that doesn't exist.

The actual issue was that my NAS account has 2FA enabled, and the integration sent otp: false in the login payload, so UGOS rejected it.

This PR has the integration send otp: true and adds a registration step. The OTP code you enter is sent to v1/verify/code/login with trust: true, which registers a UG-Client-Id as a trusted device. That Client ID is stored in the config entry and sent as a header on every later login, so the integration can log in without asking for a new code each time.